### PR TITLE
CMakeLists.txt: add libpthread to target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ set(ramses_dependencies
     ramses-framework)
 
 add_executable(obj2ramses ${source_files})
-target_link_libraries(obj2ramses ${ramses_dependencies})
+target_link_libraries(obj2ramses ${ramses_dependencies} -lpthread)
 target_include_directories(obj2ramses PRIVATE src/include)
 
 add_definitions(-DRAMSES_LINK_STATIC)

--- a/src/include/ObjGeometry.h
+++ b/src/include/ObjGeometry.h
@@ -1,0 +1,31 @@
+#ifndef GEOMETRY_H
+#define GEOMETRY_H
+
+#include <vector>
+
+namespace obj2ramses {
+namespace ObjGeometry {
+
+using std::vector;
+
+
+struct vertex3f {
+    float x, y, z;
+};
+
+struct tex_coord_3f {
+    float u, v = 0.0f, w = 0.0f;
+};
+
+struct vertex_normal_3f {
+    float x, y, z;
+};
+
+struct face {
+    vector<unsigned> v, vt, vn;
+    unsigned long len = v.size();
+};
+
+}}
+
+#endif //GEOMETRY_H

--- a/src/include/ObjImporter.h
+++ b/src/include/ObjImporter.h
@@ -11,6 +11,16 @@
 
 #include <string>
 
+#include "ObjGeometry.h"
+
+using std::string;
+using std::vector;
+
+using obj2ramses::ObjGeometry::vertex3f;
+using obj2ramses::ObjGeometry::tex_coord_3f;
+using obj2ramses::ObjGeometry::vertex_normal_3f;
+using obj2ramses::ObjGeometry::face;
+
 namespace ramses
 {
     class RamsesClient;
@@ -32,6 +42,14 @@ namespace obj2ramses
 
         ramses::RamsesClient& m_client;
         ramses::Scene& m_scene;
+
+        vector<vertex3f> vertices;
+        vector<tex_coord_3f> tex_coords;
+        vector<vertex_normal_3f> normals;
+        vector<face> faces;
+
+        std::vector<string> tokenize(string line, char delim = ' ');
+
     };
 }
 


### PR DESCRIPTION
This commit adds libpthread as the last argument of target_link_libraries
and by doing so fixes a linker error for unresolved pthread symbols.

Signed-off-by: Daniel W. S. Almeida <dwlsalmeida@gmail.com>